### PR TITLE
Promu: Configure binary name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ solr_exporter
 *-stamp
 .idea
 .tarballs
+*~

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,8 @@
 repository:
     path: github.com/noony/prometheus-solr-exporter
 build:
+    binaries:
+        - name: solr_exporter
     flags: -a -tags netgo
     ldflags: |
         -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}


### PR DESCRIPTION
Hi @noony,

I added the binary name in `.promu.yml`, otherwise the binary will be compiled as `prometheus-solr-exporter` instead of `solr_exporter`.