### PR TITLE
configurable solr context path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ prometheus-solr-exporter --help
 | Argument              | Description |
 | --------              | ----------- |
 | solr.address          | URI on which to scrape Solr. (default "http://localhost:8983") |
+| solr.context-path     | Solr webapp context path. (default "/solr") |
 | solr.pid-file         | Path to Solr pid file |
 | solr.timeout          | Timeout for trying to get stats from Solr. (default 5s) |
 | web.listen-address    | Address to listen on for web interface and telemetry. (default ":9231")|

--- a/exporter.go
+++ b/exporter.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	mbeansPath     = "/admin/mbeans?stats=true&wt=json&cat=CORE&cat=QUERYHANDLER&cat=UPDATEHANDLER&cat=CACHE"
-	adminCoresPath = "/solr/admin/cores?action=STATUS&wt=json"
+	adminCoresPath = "/admin/cores?action=STATUS&wt=json"
 )
 
 var (
@@ -112,7 +112,7 @@ type Exporter struct {
 }
 
 // NewExporter returns an initialized Exporter.
-func NewExporter(solrURI string, timeout time.Duration) *Exporter {
+func NewExporter(solrURI string, solrContextPath string, timeout time.Duration) *Exporter {
 	gaugeAdmin := make(map[string]*prometheus.GaugeVec, len(gaugeAdminMetrics))
 	gaugeCore := make(map[string]*prometheus.GaugeVec, len(gaugeCoreMetrics))
 	gaugeQuery := make(map[string]*prometheus.GaugeVec, len(gaugeQueryMetrics))
@@ -158,8 +158,8 @@ func NewExporter(solrURI string, timeout time.Duration) *Exporter {
 		}, []string{"core", "handler", "class"})
 	}
 
-	mbeansUrl := fmt.Sprintf("%s/solr/%s%s", solrURI, "%s", mbeansPath)
-	adminCoreUrl := fmt.Sprintf("%s%s", solrURI, adminCoresPath)
+	mbeansUrl := fmt.Sprintf("%s%s/%s%s", solrURI, solrContextPath, "%s", mbeansPath)
+	adminCoreUrl := fmt.Sprintf("%s%s%s", solrURI, solrContextPath, adminCoresPath)
 
 	// Init our exporter.
 	return &Exporter{

--- a/main.go
+++ b/main.go
@@ -27,11 +27,12 @@ const (
 )
 
 var (
-	listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9231").String()
-	metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-	solrURI       = kingpin.Flag("solr.address", "URI on which to scrape Solr.").Default("http://localhost:8983").String()
-	solrTimeout   = kingpin.Flag("solr.timeout", "Timeout for trying to get stats from Solr.").Default("5s").Duration()
-	solrPidFile   = kingpin.Flag("solr.pid-file", "").Default(pidFileHelpText).String()
+	listenAddress   = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9231").String()
+	metricsPath     = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+	solrURI         = kingpin.Flag("solr.address", "URI on which to scrape Solr.").Default("http://localhost:8983").String()
+	solrContextPath = kingpin.Flag("solr.context-path", "Solr webapp context path.").Default("/solr").String()
+	solrTimeout     = kingpin.Flag("solr.timeout", "Timeout for trying to get stats from Solr.").Default("5s").Duration()
+	solrPidFile     = kingpin.Flag("solr.pid-file", "").Default(pidFileHelpText).String()
 )
 
 var landingPage = []byte(`<html>
@@ -52,7 +53,7 @@ func main() {
 	log.Infoln("Starting solr_exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())
 
-	exporter := NewExporter(*solrURI, *solrTimeout)
+	exporter := NewExporter(*solrURI, *solrContextPath, *solrTimeout)
 	prometheus.MustRegister(exporter)
 	prometheus.MustRegister(version.NewCollector("solr_exporter"))
 


### PR DESCRIPTION
Solr webapp context path (default to `/solr`) can be customized in the jetty configuration. When customized the exporter is not able to read metrics. This PR adds a new argument to make it configurable.